### PR TITLE
[FIX] Remove Release plugin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,9 +7,6 @@ springBootVersion = 3.2.5
 # io.spring.gradle:dependency-management-plugin
 springBootDependencyManagementPluginVersion = 1.1.5
 
-# net.researchgate:gradle-release
-gradleReleasePluginVersion = 3.0.2
-
 # com.github.ben-manes:gradle-versions-plugin
 gradleVersionsPluginVersion = 0.51.0
 

--- a/laa-ccms-java-gradle-plugin/build.gradle
+++ b/laa-ccms-java-gradle-plugin/build.gradle
@@ -11,7 +11,6 @@ repositories {
 }
 
 dependencies {
-    implementation "net.researchgate:gradle-release:${gradleReleasePluginVersion}"
     implementation "com.github.ben-manes:gradle-versions-plugin:${gradleVersionsPluginVersion}"
 }
 

--- a/laa-ccms-java-gradle-plugin/src/main/groovy/uk/gov/laa/ccms/gradle/LaaCcmsJavaGradlePlugin.groovy
+++ b/laa-ccms-java-gradle-plugin/src/main/groovy/uk/gov/laa/ccms/gradle/LaaCcmsJavaGradlePlugin.groovy
@@ -22,10 +22,11 @@ class LaaCcmsJavaGradlePlugin implements Plugin<Project> {
 
         target.pluginManager.apply JavaPlugin
         target.pluginManager.apply JacocoPlugin
-        target.pluginManager.apply ReleasePlugin
         target.pluginManager.apply VersionsPlugin
         target.pluginManager.apply CheckstylePlugin
         target.pluginManager.apply MavenPublishPlugin
+
+        target.rootProject.pluginManager.apply ReleasePlugin
 
         target.java {
             toolchain.languageVersion.set(JavaLanguageVersion.of(JAVA_VERSION))

--- a/laa-ccms-java-gradle-plugin/src/main/groovy/uk/gov/laa/ccms/gradle/LaaCcmsJavaGradlePlugin.groovy
+++ b/laa-ccms-java-gradle-plugin/src/main/groovy/uk/gov/laa/ccms/gradle/LaaCcmsJavaGradlePlugin.groovy
@@ -26,7 +26,9 @@ class LaaCcmsJavaGradlePlugin implements Plugin<Project> {
         target.pluginManager.apply CheckstylePlugin
         target.pluginManager.apply MavenPublishPlugin
 
-        target.rootProject.pluginManager.apply ReleasePlugin
+        if (!target.rootProject.pluginManager.hasPlugin('gradle-release')) {
+            target.rootProject.pluginManager.apply ReleasePlugin
+        }
 
         target.java {
             toolchain.languageVersion.set(JavaLanguageVersion.of(JAVA_VERSION))

--- a/laa-ccms-java-gradle-plugin/src/main/groovy/uk/gov/laa/ccms/gradle/LaaCcmsJavaGradlePlugin.groovy
+++ b/laa-ccms-java-gradle-plugin/src/main/groovy/uk/gov/laa/ccms/gradle/LaaCcmsJavaGradlePlugin.groovy
@@ -1,7 +1,6 @@
 package uk.gov.laa.ccms.gradle
 
 import com.github.benmanes.gradle.versions.VersionsPlugin
-import net.researchgate.release.ReleasePlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPlugin
@@ -25,10 +24,6 @@ class LaaCcmsJavaGradlePlugin implements Plugin<Project> {
         target.pluginManager.apply VersionsPlugin
         target.pluginManager.apply CheckstylePlugin
         target.pluginManager.apply MavenPublishPlugin
-
-        if (!target.rootProject.pluginManager.hasPlugin('gradle-release')) {
-            target.rootProject.pluginManager.apply ReleasePlugin
-        }
 
         target.java {
             toolchain.languageVersion.set(JavaLanguageVersion.of(JAVA_VERSION))
@@ -173,10 +168,6 @@ class LaaCcmsJavaGradlePlugin implements Plugin<Project> {
                 logger.lifecycle("Published Maven artifact: " +
                         "${publication.groupId}:${publication.artifactId}:${publication.version}")
             }
-        }
-
-        target.release {
-            tagTemplate = '$name-$version'
         }
 
         // Used for deploying snapshot packages


### PR DESCRIPTION
Release plugin should not be applied at subproject level as the other plugins are. It will need to be applied separately by the consuming project.