### PR TITLE
Allow further Dependabot version scanning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,25 @@ plugins {
     id 'checkstyle'
 }
 
+// Set Global Versions
+
+// org.springframework.boot:spring-boot-gradle-plugin
+// org.springframework.boot:spring-boot-dependencies
+ext.springBootVersion = "3.3.4"
+
+// io.spring.gradle:dependency-management-plugin
+ext.springBootDependencyManagementPluginVersion = "1.1.6"
+
+// com.github.ben-manes:gradle-versions-plugin
+ext.gradleVersionsPluginVersion = "0.51.0"
+
+// checkstyle
+ext.checkstyleVersion = "10.18.1"
+
+// com.adarshr:gradle-test-logger-plugin
+ext.testLoggerPluginVersion = "4.0.0"
+
+
 subprojects {
     // See https://github.com/gradle/gradle/issues/22317
     tasks.withType(Test).configureEach {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,19 +1,3 @@
 version=0.0.6-SNAPSHOT
 
-# org.springframework.boot:spring-boot-gradle-plugin
-# org.springframework.boot:spring-boot-dependencies
-springBootVersion = 3.3.4
-
-# io.spring.gradle:dependency-management-plugin
-springBootDependencyManagementPluginVersion = 1.1.6
-
-# com.github.ben-manes:gradle-versions-plugin
-gradleVersionsPluginVersion = 0.51.0
-
-# checkstyle
-checkstyleVersion = 10.18.1
-
-# com.adarshr:gradle-test-logger-plugin
-testLoggerPluginVersion = 4.0.0
-
 javaVersion = 21


### PR DESCRIPTION
Dependabot doesn't scan `gradle.properties` files for dependency versions. This will allow the main dependencies injected by this library to be updated.