### PR TITLE
Fix: Add OpenApi to autoconfiguration

### DIFF
--- a/laa-ccms-spring-boot-starters/laa-ccms-spring-boot-starter-auth/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/laa-ccms-spring-boot-starters/laa-ccms-spring-boot-starter-auth/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 uk.gov.laa.ccms.springboot.auth.SecurityFilterChainAutoConfiguration
+uk.gov.laa.ccms.springboot.auth.config.OpenApiConfiguration


### PR DESCRIPTION
The OpenApi configuration was previously pulled in by the `@ComponentScan` annotation on `SecurityFilterChainAutoConfiguration`. This was removed as part of a refactor (see https://github.com/ministryofjustice/laa-ccms-spring-boot-common/pull/44). As the OpenApi is a separate piece of configuration, it has been added back separately to the autoconfiguration imports instead.